### PR TITLE
Fix obstacle collision detection

### DIFF
--- a/Entities/obstacle.py
+++ b/Entities/obstacle.py
@@ -4,13 +4,19 @@ class Obstacle:
     def __init__(self, x=0, y=0):
         self.x = x
         self.y = y
-        self.width = 20
-        self.height = 50
-        self.obstacle_frame= pygame.image.load("Sprites/extras/truck.png").convert_alpha()
+        # match obstacle sprite dimensions for accurate collisions
+        self.width = 120
+        self.height = 80
+        self.obstacle_frame = pygame.image.load(
+            "Sprites/extras/truck.png"
+        ).convert_alpha()
     
     def draw(self, surface, scroll_x=0):
-        frame =  pygame.transform.scale(self.obstacle_frame, (120, 80))
-        surface.blit(frame, (self.x - scroll_x, self.y - self.height))  # restamos para igualar la altura del obstaculo con el sprite
+        frame = pygame.transform.scale(self.obstacle_frame, (self.width, self.height))
+        surface.blit(
+            frame,
+            (self.x - scroll_x, self.y - self.height),
+        )  # restamos para igualar la altura del obstaculo con el sprite
 
     def move(self):
         self.x -= 5

--- a/main.py
+++ b/main.py
@@ -173,7 +173,7 @@ def check_collisions(character, character_bullets, soldiers, flying_killers,
     for obstacle in obstacles[:]:
         obstacle_rect = pygame.Rect(
             obstacle.position[0] - scroll_x,
-            obstacle.position[1],
+            obstacle.position[1] - obstacle.size[1],
             obstacle.size[0],
             obstacle.size[1],
         )


### PR DESCRIPTION
## Summary
- adjust obstacle sprite dimensions and drawing
- fix obstacle rect position for collision detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572cb498388325b448264c4886ca14